### PR TITLE
Send response instead of error when rejecting

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -17,7 +17,7 @@ const middleware = () => {
         const key = generateThunkKey(action)
         next(createThunkAction(action, key))
         return new Promise((resolve, reject) => {
-          responses[key] = (err, response) => (err ? reject(err) : resolve(response))
+          responses[key] = (err, response) => (err ? reject(response) : resolve(response))
         })
       }
       const key = getThunkMeta(action)


### PR DESCRIPTION
This PR will fix issues reported in #3 

By rejecting with the `response` and not the `error` (which should always be a boolean) we'll make used of the payload sent through the action.